### PR TITLE
AddNewFile Argument Fix

### DIFF
--- a/11-Scripting-Functions.html
+++ b/11-Scripting-Functions.html
@@ -1093,8 +1093,8 @@ title: xEdit Scripting Functions
                 </tr>
                 <tr>
                     <td><b>AddNewFileName</b></td>
-                    <td></td>
-                    <td> aeFile: IwbFile<br/>
+                    <td> aeFile: IwbFile</td>
+                    <td><br/>
                     </td>
                     <td> Creates a new, empty plugin in the game's plugin folder (Data) and adds it to the end of the
                         plugins list.


### PR DESCRIPTION
AddNewFileName (aka AddNewFile) had IwbFile listed as an argument and nothing listed as a return value, AddNewFile returns the file it creates, and unless I am missing information, it doesnt accept any arguments.